### PR TITLE
GoogleApiClient deprecated fix

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNSmsRetrieverBroadcastReciever.java
+++ b/android/src/main/java/com/reactlibrary/RNSmsRetrieverBroadcastReciever.java
@@ -4,7 +4,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.facebook.react.bridge.ReactApplicationContext;


### PR DESCRIPTION
When building the React Native app, an error was encountered due to the deprecation of GoogleApiClient. The error specifically affected the availability of com.google.android.gms.auth.api.credentials.*, causing the build to fail.

Error: `Execution failed for task ':react-native-sms-retriever-api:compileDebugJavaWithJavac'.`

The issue is discussed on Stack Overflow: [Link to Stack Overflow Question](https://stackoverflow.com/questions/60690008/how-to-use-googleapiclient-deprecated-with-smsretriver-api-in-android)

Fixed the issue by using new GoogleApi.